### PR TITLE
Add tabbed main window with theme support

### DIFF
--- a/GUI/README.md
+++ b/GUI/README.md
@@ -7,7 +7,7 @@ This directory contains a simple PyQt6 application scaffold for the gallery-dl G
 ```bash
 python -m venv venv
 source venv/bin/activate
-pip install PyQt6
+pip install PyQt6 qdarktheme
 python -m gui.main
 ```
 

--- a/GUI/gui/main.py
+++ b/GUI/gui/main.py
@@ -1,5 +1,7 @@
-from PyQt6 import QtWidgets
 from pathlib import Path
+
+from PyQt6 import QtWidgets
+import qdarktheme
 
 from .config import Config
 from .downloader import ensure_gallery_dl
@@ -15,10 +17,30 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("gallery-dl GUI")
         self.resize(800, 600)
 
+        # Central tab widget
+        tabs = QtWidgets.QTabWidget()
+        self.setCentralWidget(tabs)
+
+        tabs.addTab(QtWidgets.QWidget(), "Downloads")
+        tabs.addTab(QtWidgets.QWidget(), "Options")
+        tabs.addTab(QtWidgets.QWidget(), "History/Logs")
+
+        settings_tab = QtWidgets.QWidget()
+        settings_layout = QtWidgets.QVBoxLayout(settings_tab)
+        open_settings_button = QtWidgets.QPushButton("Open Settings…")
+        open_settings_button.clicked.connect(self._show_settings)
+        settings_layout.addWidget(open_settings_button)
+        settings_layout.addStretch()
+        tabs.addTab(settings_tab, "Settings")
+
+        # Toolbar
         settings_action = QtWidgets.QAction("Settings", self)
         settings_action.triggered.connect(self._show_settings)
-        menu = self.menuBar().addMenu("Options")
-        menu.addAction(settings_action)
+        toolbar = self.addToolBar("Main")
+        toolbar.addAction(settings_action)
+
+        # Status bar
+        self.statusBar().showMessage("Ready")
 
     def _show_settings(self) -> None:
         dialog = SettingsDialog(self._config, self)
@@ -30,6 +52,7 @@ class MainWindow(QtWidgets.QMainWindow):
 def main() -> None:
     """Launch the gallery-dl GUI."""
     app = QtWidgets.QApplication([])
+    qdarktheme.setup_theme()
     config = Config.load()
     ensure_gallery_dl(Path(config.gallery_dl_path))
     window = MainWindow(config)


### PR DESCRIPTION
## Summary
- build QMainWindow with toolbar, status bar, and tabbed interface
- integrate qdarktheme for light/dark appearance
- update GUI setup instructions to include qdarktheme

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_689e4334cdf08331ace6b8b3f834bb84